### PR TITLE
Use bindings for -D_FILE_OFFSET_BITS=64

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -152,7 +152,7 @@ fn main() {
         match field {
             // Our stat *_nsec fields normally don't actually exist but are part
             // of a timeval struct
-            s if s.ends_with("_nsec") && struct_ == "stat" => {
+            s if s.ends_with("_nsec") && struct_.starts_with("stat") => {
                 if target2.contains("apple") {
                     s.replace("_nsec", "spec.tv_nsec")
                 } else if target2.contains("android") {
@@ -203,6 +203,12 @@ fn main() {
             // types on musl are defined a little differently
             n if musl && n.contains("__SIZEOF_PTHREAD") => true,
 
+            // Skip constants not defined in MUSL but just passed down to the
+            // kernel regardless
+            "RLIMIT_NLIMITS" |
+            "TCP_COOKIE_TRANSACTIONS" |
+            "RLIMIT_RTTIME" if musl => true,
+
             _ => false,
         }
     });
@@ -215,8 +221,8 @@ fn main() {
             "execvp" |
             "execvpe" => true,
 
-            "getrlimit" |                    // non-int in 1st arg
-            "setrlimit" |                    // non-int in 1st arg
+            "getrlimit" | "getrlimit64" |    // non-int in 1st arg
+            "setrlimit" | "setrlimit64" |    // non-int in 1st arg
             "strerror_r" if linux => true,   // actually xpg-something-or-other
 
             // typed 2nd arg on linux and android

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub type uintptr_t = usize;
 pub type ssize_t = isize;
 
 pub enum FILE {}
-pub enum fpos_t {}
+pub enum fpos_t {} // TODO: fill this out with a struct
 
 extern {
     pub fn isalnum(c: c_int) -> c_int;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -174,7 +174,7 @@ extern {
     pub fn opendir(dirname: *const c_char) -> *mut ::DIR;
     #[cfg_attr(target_os = "macos", link_name = "readdir_r$INODE64")]
     pub fn readdir_r(dirp: *mut ::DIR, entry: *mut ::dirent,
-                      result: *mut *mut ::dirent) -> ::c_int;
+                     result: *mut *mut ::dirent) -> ::c_int;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "closedir$UNIX2003")]
     pub fn closedir(dirp: *mut ::DIR) -> ::c_int;
@@ -220,8 +220,7 @@ extern {
     pub fn getuid() -> uid_t;
     pub fn isatty(fd: ::c_int) -> ::c_int;
     pub fn link(src: *const c_char, dst: *const c_char) -> ::c_int;
-    pub fn lseek(fd: ::c_int, offset: off_t, whence: ::c_int)
-                 -> off_t;
+    pub fn lseek(fd: ::c_int, offset: off_t, whence: ::c_int) -> off_t;
     pub fn pathconf(path: *const c_char, name: ::c_int) -> c_long;
     #[cfg_attr(all(target_os = "macos", target_arch = "x86"),
                link_name = "pause$UNIX2003")]
@@ -526,6 +525,10 @@ extern {
                    errorfds: *mut fd_set,
                    timeout: *const timespec,
                    sigmask: *const sigset_t) -> ::c_int;
+    pub fn fseeko(stream: *mut ::FILE,
+                  offset: ::off_t,
+                  whence: ::c_int) -> ::c_int;
+    pub fn ftello(stream: *mut ::FILE) -> ::off_t;
 }
 
 cfg_if! {

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -14,7 +14,7 @@ pub type nlink_t = u32;
 s! {
     pub struct stat {
         pub st_dev: ::c_ulong,
-        pub st_pad1: [::c_long; 3],
+        st_pad1: [::c_long; 3],
         pub st_ino: ::ino_t,
         pub st_mode: ::mode_t,
         pub st_nlink: ::nlink_t,
@@ -23,7 +23,7 @@ s! {
         pub st_rdev: ::c_ulong,
         pub st_pad2: [::c_long; 2],
         pub st_size: ::off_t,
-        pub st_pad3: ::c_long,
+        st_pad3: ::c_long,
         pub st_atime: ::time_t,
         pub st_atime_nsec: ::c_long,
         pub st_mtime: ::time_t,
@@ -32,7 +32,30 @@ s! {
         pub st_ctime_nsec: ::c_long,
         pub st_blksize: ::blksize_t,
         pub st_blocks: ::blkcnt_t,
-        pub st_pad5: [::c_long; 14],
+        st_pad5: [::c_long; 14],
+    }
+
+    pub struct stat64 {
+        pub st_dev: ::c_ulong,
+        st_pad1: [::c_long; 3],
+        pub st_ino: ::ino64_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::c_ulong,
+        st_pad2: [::c_long; 2],
+        pub st_size: ::off64_t,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        pub st_blksize: ::blksize_t,
+        st_pad3: ::c_long,
+        pub st_blocks: ::blkcnt64_t,
+        st_pad5: [::c_long; 14],
     }
 
     pub struct pthread_attr_t {

--- a/src/unix/notbsd/linux/musl.rs
+++ b/src/unix/notbsd/linux/musl.rs
@@ -1,0 +1,10 @@
+pub const BUFSIZ: ::c_uint = 1024;
+pub const TMP_MAX: ::c_uint = 10000;
+pub const FOPEN_MAX: ::c_uint = 1000;
+pub const POSIX_MADV_DONTNEED: ::c_int = 0;
+pub const O_ACCMODE: ::c_int = 0o10000003;
+pub const RUSAGE_CHILDREN: ::c_int = 1;
+
+extern {
+    pub fn ioctl(fd: ::c_int, request: ::c_int, ...) -> ::c_int;
+}

--- a/src/unix/notbsd/linux/notmips/b32/mod.rs
+++ b/src/unix/notbsd/linux/notmips/b32/mod.rs
@@ -40,6 +40,28 @@ s! {
         __unused5: ::c_long,
     }
 
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        __pad1: ::c_uint,
+        __st_ino: ::ino_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __pad2: ::c_uint,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt64_t,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        pub st_ino: ::ino64_t,
+    }
+
     pub struct pthread_attr_t {
         __size: [u32; 9]
     }

--- a/src/unix/notbsd/linux/notmips/b64/aarch64.rs
+++ b/src/unix/notbsd/linux/notmips/b64/aarch64.rs
@@ -31,6 +31,28 @@ s! {
         __unused: [::c_int; 2],
     }
 
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino_t,
+        pub st_mode: ::mode_t,
+        pub st_nlink: ::nlink_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        pub st_rdev: ::dev_t,
+        __pad1: ::dev_t,
+        pub st_size: ::off64_t,
+        pub st_blksize: ::blksize_t,
+        __pad2: ::c_int,
+        pub st_blocks: ::blkcnt64_t,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        __unused: [::c_int; 2],
+    }
+
     pub struct pthread_attr_t {
         __size: [u64; 8]
     }

--- a/src/unix/notbsd/linux/notmips/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/notmips/b64/x86_64.rs
@@ -30,6 +30,27 @@ s! {
         __unused: [::c_long; 3],
     }
 
+    pub struct stat64 {
+        pub st_dev: ::dev_t,
+        pub st_ino: ::ino64_t,
+        pub st_nlink: ::nlink_t,
+        pub st_mode: ::mode_t,
+        pub st_uid: ::uid_t,
+        pub st_gid: ::gid_t,
+        __pad0: ::c_int,
+        pub st_rdev: ::dev_t,
+        pub st_size: ::off_t,
+        pub st_blksize: ::blksize_t,
+        pub st_blocks: ::blkcnt64_t,
+        pub st_atime: ::time_t,
+        pub st_atime_nsec: ::c_long,
+        pub st_mtime: ::time_t,
+        pub st_mtime_nsec: ::c_long,
+        pub st_ctime: ::time_t,
+        pub st_ctime_nsec: ::c_long,
+        __reserved: [::c_long; 3],
+    }
+
     pub struct pthread_attr_t {
         __size: [u64; 7]
     }

--- a/src/unix/notbsd/linux/notmips/mod.rs
+++ b/src/unix/notbsd/linux/notmips/mod.rs
@@ -27,6 +27,8 @@ pub const RLIMIT_AS: ::c_int = 9;
 pub const RLIMIT_NPROC: ::c_int = 6;
 pub const RLIMIT_MEMLOCK: ::c_int = 8;
 pub const RLIM_INFINITY: ::rlim_t = !0;
+pub const RLIMIT_RTTIME: ::c_int = 15;
+pub const RLIMIT_NLIMITS: ::c_int = 16;
 
 pub const O_APPEND: ::c_int = 1024;
 pub const O_CREAT: ::c_int = 64;
@@ -148,12 +150,14 @@ pub const SO_RCVBUF: ::c_int = 8;
 pub const SO_KEEPALIVE: ::c_int = 9;
 pub const SO_OOBINLINE: ::c_int = 10;
 pub const SO_LINGER: ::c_int = 13;
+pub const SO_REUSEPORT: ::c_int = 15;
 pub const SO_RCVLOWAT: ::c_int = 18;
 pub const SO_SNDLOWAT: ::c_int = 19;
 pub const SO_RCVTIMEO: ::c_int = 20;
 pub const SO_SNDTIMEO: ::c_int = 21;
 pub const SO_ACCEPTCONN: ::c_int = 30;
 
+pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
 pub const TCP_THIN_LINEAR_TIMEOUTS: ::c_int = 16;
 pub const TCP_THIN_DUPACK: ::c_int = 17;
 pub const TCP_USER_TIMEOUT: ::c_int = 18;
@@ -163,8 +167,6 @@ pub const TCP_QUEUE_SEQ: ::c_int = 21;
 pub const TCP_REPAIR_OPTIONS: ::c_int = 22;
 pub const TCP_FASTOPEN: ::c_int = 23;
 pub const TCP_TIMESTAMP: ::c_int = 24;
-
-pub const SO_REUSEPORT: ::c_int = 15;
 
 pub const FIOCLEX: ::c_ulong = 0x5451;
 pub const FIONBIO: ::c_ulong = 0x5421;
@@ -176,16 +178,6 @@ pub const SA_NOCLDWAIT: ::c_int = 0x00000002;
 pub const SIGCHLD: ::c_int = 17;
 pub const SIGBUS: ::c_int = 7;
 pub const SIG_SETMASK: ::c_int = 2;
-
-cfg_if! {
-    if #[cfg(target_env = "musl")] {
-        pub const RLIMIT_NLIMITS: ::c_int = 15;
-    } else {
-        pub const RLIMIT_NLIMITS: ::c_int = 16;
-        pub const RLIMIT_RTTIME: ::c_int = 15;
-        pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
-    }
-}
 
 cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "arm"))] {

--- a/src/unix/notbsd/linux/notmusl.rs
+++ b/src/unix/notbsd/linux/notmusl.rs
@@ -1,0 +1,42 @@
+s! {
+    pub struct glob64_t {
+        pub gl_pathc: ::size_t,
+        pub gl_pathv: *mut *mut ::c_char,
+        pub gl_offs: ::size_t,
+        pub gl_flags: ::c_int,
+
+        __unused1: *mut ::c_void,
+        __unused2: *mut ::c_void,
+        __unused3: *mut ::c_void,
+        __unused4: *mut ::c_void,
+        __unused5: *mut ::c_void,
+    }
+}
+
+pub const BUFSIZ: ::c_uint = 8192;
+pub const TMP_MAX: ::c_uint = 238328;
+pub const FOPEN_MAX: ::c_uint = 16;
+pub const POSIX_MADV_DONTNEED: ::c_int = 4;
+pub const _SC_2_C_VERSION: ::c_int = 96;
+pub const RUSAGE_THREAD: ::c_int = 1;
+pub const O_ACCMODE: ::c_int = 3;
+pub const RUSAGE_CHILDREN: ::c_int = -1;
+
+extern {
+    pub fn sysctl(name: *mut ::c_int,
+                  namelen: ::c_int,
+                  oldp: *mut ::c_void,
+                  oldlenp: *mut ::size_t,
+                  newp: *mut ::c_void,
+                  newlen: ::size_t)
+                  -> ::c_int;
+    pub fn ioctl(fd: ::c_int, request: ::c_ulong, ...) -> ::c_int;
+    pub fn backtrace(buf: *mut *mut ::c_void,
+                     sz: ::c_int) -> ::c_int;
+    pub fn glob64(pattern: *const ::c_char,
+                  flags: ::c_int,
+                  errfunc: ::dox::Option<extern "C" fn(epath: *const ::c_char,
+                                                       errno: ::c_int) -> ::c_int>,
+                  pglob: *mut glob64_t) -> ::c_int;
+    pub fn globfree64(pglob: *mut glob64_t);
+}


### PR DESCRIPTION
This should help "by default" dealing with large files on 32-bit Linux. Other platforms can opt in where necessary as well.