### PR TITLE
Fix undeclared type name errors when targeting android aarch64.

### DIFF
--- a/src/unix/notbsd/android/b64.rs
+++ b/src/unix/notbsd/android/b64.rs
@@ -1,8 +1,8 @@
 s! {
     pub struct sigaction {
         pub sa_flags: ::c_uint,
-        pub sa_sigaction: sighandler_t,
-        pub sa_mask: sigset_t,
+        pub sa_sigaction: ::sighandler_t,
+        pub sa_mask: ::sigset_t,
         _restorer: *mut ::c_void,
     }
 }


### PR DESCRIPTION
Resolves `use of undeclared type name` errors for `sighandler_t` and `sigset_t` when compiling for `aarch64-linux-android`.