### PR TITLE
Remove reference to raw_pointer_derive lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 
 //! Crate docs
 
-#![allow(bad_style, raw_pointer_derive, overflowing_literals, improper_ctypes)]
+#![allow(bad_style, overflowing_literals, improper_ctypes)]
 #![crate_type = "rlib"]
 #![crate_name = "libc"]
 #![cfg_attr(dox, feature(no_core, lang_items))]


### PR DESCRIPTION
Part of rust-lang pull-request [#29882](https://github.com/rust-lang/rust/pull/29882), which implements [#14615](https://github.com/rust-lang/rust/issues/14615) (Remove raw_pointer_deriving lint)