### PR TITLE
Add SO_REUSEPORT for Android

### DIFF
--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -373,6 +373,7 @@ pub const SO_RCVBUF: ::c_int = 8;
 pub const SO_KEEPALIVE: ::c_int = 9;
 pub const SO_OOBINLINE: ::c_int = 10;
 pub const SO_LINGER: ::c_int = 13;
+pub const SO_REUSEPORT: ::c_int = 15;
 pub const SO_RCVLOWAT: ::c_int = 18;
 pub const SO_SNDLOWAT: ::c_int = 19;
 pub const SO_RCVTIMEO: ::c_int = 20;


### PR DESCRIPTION
The `net2` crate currently fails to cross-compile to Android with ``error: unresolved name `libc::SO_REUSEPORT` ``

According to http://stackoverflow.com/a/14388707/1162888, Android is essentially the same as Linux for the purpose of socket features support, and the Linux kernel has supported `SO_REUSEPORT` since version 3.9.

According to http://android.stackexchange.com/a/51656, Android has had more recent kernels than that since version 4.4 Kit Kat.

(This blocks https://github.com/servo/servo/pull/8446.)