### PR TITLE
Re-export c_void from std::os::raw

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,17 +73,7 @@ extern crate std as core;
 #[macro_use] mod macros;
 mod dox;
 
-// Use repr(u8) as LLVM expects `void*` to be the same as `i8*` to help enable
-// more optimization opportunities around it recognizing things like
-// malloc/free.
-#[repr(u8)]
-pub enum c_void {
-    // Two dummy variants so the #[repr] attribute can be used.
-    #[doc(hidden)]
-    __variant1,
-    #[doc(hidden)]
-    __variant2,
-}
+pub use core::os::raw::c_void;
 
 pub type int8_t = i8;
 pub type int16_t = i16;


### PR DESCRIPTION
This avoid silly errors like:

```
error: mismatched types:
 expected `*mut libc::c_void`,
    found `*mut std::os::raw::c_void`
```

and should have no other effect since the two definitions were identical.

CC https://github.com/servo/servo/pull/8446