### PR TITLE
Remove `#[staged_api]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 ))]
 
 // Attributes needed when building as part of the standard library
-#![cfg_attr(stdbuild, feature(no_std, core, core_slice_ext, staged_api))]
+#![cfg_attr(stdbuild, feature(no_std, core, core_slice_ext, staged_api, custom_attribute))]
 #![cfg_attr(stdbuild, no_std)]
 #![cfg_attr(stdbuild, staged_api)]
 #![cfg_attr(stdbuild, allow(warnings))]


### PR DESCRIPTION
Part of https://github.com/rust-lang/rust/pull/30015

I'm not sure how versions of rustc and libc correspond to each other now, so I used `custom_attribute` instead of `stage0`, i.e. libc can be used with any compiler version supporting or not supporting `staged_api`