### PR TITLE
unbreak openbsd and bitrig due to linking to rt

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -107,7 +107,9 @@ cfg_if! {
         extern {}
     } else if #[cfg(any(target_os = "macos",
                         target_os = "ios",
-                        target_os = "android"))] {
+                        target_os = "android",
+                        target_os = "openbsd",
+                        target_os = "bitrig"))] {
         #[link(name = "c")]
         #[link(name = "m")]
         extern {}


### PR DESCRIPTION
openbsd and bitrig don't have librt. So do not try to link with.

cc @alexcrichton @dhuseby