### PR TITLE
Fix freebsd-likes stage2 build

### DIFF
--- a/src/unix/bsd/freebsdlike/dragonfly.rs
+++ b/src/unix/bsd/freebsdlike/dragonfly.rs
@@ -1,6 +1,6 @@
 pub const PTHREAD_STACK_MIN: ::size_t = 1024;
 pub const KERN_PROC_PATHNAME: ::c_int = 9;
-pub const SIGSTKSZ: ::size_t = 8192 /* MINSIGSTKSZ */ + 32768;
+pub const SIGSTKSZ: ::size_t = 40960;
 
 extern {
     pub fn __dfly_error() -> *const ::c_int;

--- a/src/unix/bsd/freebsdlike/freebsd.rs
+++ b/src/unix/bsd/freebsdlike/freebsd.rs
@@ -1,6 +1,6 @@
 pub const PTHREAD_STACK_MIN: ::size_t = 2048;
 pub const KERN_PROC_PATHNAME: ::c_int = 12;
-pub const SIGSTKSZ: ::size_t = 2048 /* MINSIGSTKSZ */ + 32768;
+pub const SIGSTKSZ: ::size_t = 34816;
 
 extern {
     pub fn __error() -> *mut ::c_int;


### PR DESCRIPTION
Compiling rust on master fails with this error:

```
src/liblibc/src/unix/bsd/freebsdlike/freebsd.rs:3:32: 3:36 note: an implementation of `std::ops::Add` might be missing for `_`
src/liblibc/src/unix/bsd/freebsdlike/freebsd.rs:3 pub const SIGSTKSZ: ::size_t = 2048 /* MINSIGSTKSZ */ + 32768;
```

It might be better to investigate and fix the real cause.