### PR TITLE
Add RTLD_NEXT and RTLD_DEFAULT

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -256,6 +256,9 @@ pub const ST_IMMUTABLE: ::c_ulong = 512;
 pub const ST_NOATIME: ::c_ulong = 1024;
 pub const ST_NODIRATIME: ::c_ulong = 2048;
 
+pub const RTLD_NEXT: ::c_long = -1;
+pub const RTLD_DEFAULT: ::c_long = 0;
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub const MAP_32BIT: ::c_int = 0x0040;
 

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -256,8 +256,8 @@ pub const ST_IMMUTABLE: ::c_ulong = 512;
 pub const ST_NOATIME: ::c_ulong = 1024;
 pub const ST_NODIRATIME: ::c_ulong = 2048;
 
-pub const RTLD_NEXT: ::c_long = -1;
-pub const RTLD_DEFAULT: ::c_long = 0;
+pub const RTLD_NEXT: *mut ::c_void = -1i64 as *mut ::c_void;
+pub const RTLD_DEFAULT: *mut ::c_void = 0i64 as *mut ::c_void;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub const MAP_32BIT: ::c_int = 0x0040;


### PR DESCRIPTION
This change adds RTLD_NEXT and RTLD_DEFAULT to libc. These two constants are useful when calling dlsym.