### PR TITLE
Add Linux constants for fcntl commands

### DIFF
--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -129,6 +129,11 @@ pub const F_GETFD: ::c_int = 1;
 pub const F_SETFD: ::c_int = 2;
 pub const F_GETFL: ::c_int = 3;
 pub const F_SETFL: ::c_int = 4;
+pub const F_GETLK : ::c_int = 5;
+pub const F_SETLK : ::c_int = 6;
+pub const F_SETLKW : ::c_int = 7;
+pub const F_SETOWN : ::c_int = 8;
+pub const F_GETOWN : ::c_int = 9;
 
 pub const SIGTRAP: ::c_int = 5;
 


### PR DESCRIPTION
I took these values from https://github.com/lattera/glibc/blob/a2f34833b1042d5d8eeb263b4cf4caaea138c4ad/sysdeps/unix/sysv/linux/x86/bits/fcntl.h  I'm not sure if they should go in an x86-specific module instead.