### PR TITLE
Add PATH_MAX for FreeBSDlike, defined in /usr/src/sys/sys/syslimits.h

### DIFF
--- a/src/unix/bsd/apple/mod.rs
+++ b/src/unix/bsd/apple/mod.rs
@@ -571,8 +571,6 @@ pub const SO_DONTTRUNC: ::c_int = 0x2000;
 pub const SO_WANTMORE: ::c_int = 0x4000;
 pub const SO_WANTOOBFLAG: ::c_int = 0x8000;
 
-pub const PATH_MAX: ::c_int = 1024;
-
 pub const _SC_ARG_MAX: ::c_int = 1;
 pub const _SC_CHILD_MAX: ::c_int = 2;
 pub const _SC_CLK_TCK: ::c_int = 3;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -477,8 +477,6 @@ pub const MAP_NOCORE: ::c_int = 0x020000;
 
 pub const IPPROTO_RAW: ::c_int = 255;
 
-pub const PATH_MAX: ::c_int = 1024;
-
 pub const _SC_ARG_MAX: ::c_int = 1;
 pub const _SC_CHILD_MAX: ::c_int = 2;
 pub const _SC_CLK_TCK: ::c_int = 3;

--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -477,6 +477,8 @@ pub const MAP_NOCORE: ::c_int = 0x020000;
 
 pub const IPPROTO_RAW: ::c_int = 255;
 
+pub const PATH_MAX: ::c_int = 1024;
+
 pub const _SC_ARG_MAX: ::c_int = 1;
 pub const _SC_CHILD_MAX: ::c_int = 2;
 pub const _SC_CLK_TCK: ::c_int = 3;

--- a/src/unix/bsd/mod.rs
+++ b/src/unix/bsd/mod.rs
@@ -79,6 +79,8 @@ s! {
 pub const FIOCLEX: ::c_ulong = 0x20006601;
 pub const FIONBIO: ::c_ulong = 0x8004667e;
 
+pub const PATH_MAX: ::c_int = 1024;
+
 pub const SA_ONSTACK: ::c_int = 0x0001;
 pub const SA_SIGINFO: ::c_int = 0x0040;
 pub const SA_RESTART: ::c_int = 0x0002;

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -324,8 +324,6 @@ pub const CTL_KERN : ::c_int = 1;
 
 pub const IPPROTO_RAW : ::c_int = 255;
 
-pub const PATH_MAX: ::c_int = 1024;
-
 pub const _SC_ARG_MAX : ::c_int = 1;
 pub const _SC_CHILD_MAX : ::c_int = 2;
 pub const _SC_NGROUPS_MAX : ::c_int = 4;


### PR DESCRIPTION
Trying to build nix on FreeBSD, I get this:

```
/home/vagrant/.cargo/registry/src/github.com-0a35038f75765ae4/nix-0.4.2/src/lib.rs:46:20: 46:28 error: unresolved import `libc::PATH_MAX`. There is no `PATH_MAX` in `libc` [E0432]
/home/vagrant/.cargo/registry/src/github.com-0a35038f75765ae4/nix-0.4.2/src/lib.rs:46 use libc::{c_char, PATH_MAX};
                                                                                                         ^~~~~~~~
```

Doing some sleuthing, I found a definition in `/usr/src/sys/sys/syslimits.h` on FreeBSD 10.2, it contains:

```
#define PATH_MAX                 1024   /* max bytes in pathname */
```