### PR TITLE
Add binding for memrchr on Linux

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -575,6 +575,7 @@ extern {
                            len: ::off_t) -> ::c_int;
     pub fn sched_setscheduler(pid: ::pid_t, policy: ::c_int, param: *const sched_param) -> ::c_int;
     pub fn sched_getscheduler(pid: ::pid_t) -> ::c_int;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 }
 
 cfg_if! {

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -363,6 +363,7 @@ extern {
     pub fn pthread_set_name_np(tid: ::pthread_t, name: *const ::c_char);
     pub fn pthread_stackseg_np(thread: ::pthread_t,
                                sinfo: *mut ::stack_t) -> ::c_uint;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 }
 
 cfg_if! {

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -606,6 +606,7 @@ extern {
                  arg: *mut ::c_void, ...) -> ::c_int;
     pub fn statfs(path: *const ::c_char, buf: *mut statfs) -> ::c_int;
     pub fn fstatfs(fd: ::c_int, buf: *mut statfs) -> ::c_int;
+    pub fn memrchr(cx: *const ::c_void, c: ::c_int, n: ::size_t) -> *mut ::c_void;
 }
 
 cfg_if! {


### PR DESCRIPTION
This PR adds a binding for `memrchr` on Linux and Free, Open and NetBSD. 

I hope that's okay, `memrchr` should be included in recent versions of  [FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=memrchr&sektion=3&manpath=FreeBSD+7.1-RELEASE), [OpenBSD](http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man3/memchr.3?query=memrchr&sec=3) and [NetBSD](http://man.netbsd.org/7.0/usr/share/man/html3/memrchr.htm)