### PR TITLE
Add getentropy(2)'s syscall number as a const

### DIFF
--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -212,7 +212,7 @@ pub const HW_AVAILCPU: ::c_int = 25;
 pub const KERN_PROC_ARGS: ::c_int = 55;
 
 // syscall numbers
-pub const NR_GETENTROPY: c_int = 7;
+pub const NR_GETENTROPY: ::c_int = 7;
 
 extern {
     pub fn mprotect(addr: *const ::c_void, len: ::size_t, prot: ::c_int)

--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -211,6 +211,9 @@ pub const PTHREAD_MUTEX_RECURSIVE: ::c_int = 2;
 pub const HW_AVAILCPU: ::c_int = 25;
 pub const KERN_PROC_ARGS: ::c_int = 55;
 
+// syscall numbers
+pub const NR_GETENTROPY: c_int = 7;
+
 extern {
     pub fn mprotect(addr: *const ::c_void, len: ::size_t, prot: ::c_int)
                     -> ::c_int;


### PR DESCRIPTION
I'm not convinced that the NR_* naming scheme is ideal, but it's pretty
good.

I didn't recognize any other syscall numbers in the file, so I started a
new section.