### PR TITLE
openbsd: map `si_addr` inside `struct siginfo_t`

### DIFF
--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -99,8 +99,8 @@ s! {
         pub si_signo: ::c_int,
         pub si_code: ::c_int,
         pub si_errno: ::c_int,
-        __pad1: ::c_int,
-        __pad2: [u8; 240],
+        pub si_addr: *mut ::c_void,
+        __pad: [u8; 116],
     }
 }
 


### PR DESCRIPTION
formally, under OpenBSD, `si_addr` is part of a C union. As we don't use
others members of the union inside `struct siginfo_t`, it should be safe
to directly map the field.

cc @mmcco 