### PR TITLE
nlink_t depends on pointer width on android

### DIFF
--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -13,7 +13,6 @@ pub type blkcnt_t = u32;
 pub type blksize_t = u32;
 pub type dev_t = u32;
 pub type mode_t = u16;
-pub type nlink_t = u32;
 pub type useconds_t = u32;
 pub type socklen_t = i32;
 pub type pthread_t = c_long;
@@ -558,9 +557,11 @@ cfg_if! {
     if #[cfg(target_pointer_width = "32")] {
         mod b32;
         pub use self::b32::*;
+        pub type nlink_t = u16;
     } else if #[cfg(target_pointer_width = "64")] {
         mod b64;
         pub use self::b64::*;
+        pub type nlink_t = u32;
     } else {
         // ...
     }


### PR DESCRIPTION
`nlink_t` on android seems to depend on the pointer width. I noticed that when enabling [`os::raw::tests::unix`](https://github.com/rust-lang/rust/pull/30458/files#diff-c4f9e907b21efdcec1a2c091ff9ee641R92) which failed because the `nlink_t` sizes did not match.

I only found a pretty old definition of `[__kernel_nlink_t](http://osxr.org:8080/android/source/bionic/libc/kernel/arch-arm/asm/posix_types.h#0024)` which used `unsigned short` which should be 2 bytes on 32 bit architectures, and 4 bytes on 64 bit.