### PR TITLE
Add c_bool to libc.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub type uint16_t = u16;
 pub type uint32_t = u32;
 pub type uint64_t = u64;
 
+pub type c_bool = bool;
 pub type c_schar = i8;
 pub type c_uchar = u8;
 pub type c_short = i16;


### PR DESCRIPTION
This is a fix for #116.

The `libc` crate is supposed to provide a Rust type corresponding to each C type that might appear in a public API, for use in making foreign calls. However, `libc` doesn't provide any type designated to correspond to a C `bool`.

In practice, Rust's `bool` and the `bool` of every C ABI I'm aware of are the same, so using the Rust `bool` directly in foreign function interfaces will work fine on these systems. But the `libc` crate's principle is to provide types that match *by definition*, which isn't true of Rust `bool`, so `libc::c_bool` is still valuable.

I considered whether it was better to let `c_bool` be `u8` or `bool`. In both C and C++, converting a value to a `bool` forces it to be either zero or one. Using Rust `bool` for `c_bool` mimics this behavior, whereas `u8` would allow Rust code to pass other values. I *think* forcing a C `bool` to a value other than zero or one is undefined behavior, but I can't find the language to that effect right now. Either way, it seems like Rust's `bool` is the better match.