### PR TITLE
The type of eventfd's 'initval' argument should be unsigned.

### DIFF
--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -435,7 +435,7 @@ extern {
                        serv: *mut ::c_char,
                        sevlen: ::socklen_t,
                        flags: ::c_int) -> ::c_int;
-    pub fn eventfd(init: ::c_int, flags: ::c_int) -> ::c_int;
+    pub fn eventfd(init: ::c_uint, flags: ::c_int) -> ::c_int;
     pub fn ptrace(request: ::c_uint, ...) -> ::c_long;
 }
 


### PR DESCRIPTION
This is a fix for issue #120.

I've noticed that, of the four definitions for `eventfd` in the tree, if this pull request is accepted, three use `c_uint` for the first argument, and the only remaining one is `src/unix/notbsd/linux/mips.rs`, which I suspect is not being tested much. If we can find anyone to test the MIPS build, we might well find that the correct fix is to simply common up the three linux definitions into a single one in `src/linux/notbsd/linux.mod.rs`, which would be nice.