### PR TITLE
libc-test's C program should not #include <linux/fs.h> on Linux

### DIFF
--- a/libc-test/build.rs
+++ b/libc-test/build.rs
@@ -149,7 +149,6 @@ fn main() {
         if !musl {
             cfg.header("linux/netlink.h");
             cfg.header("linux/magic.h");
-            cfg.header("linux/fs.h");
 
             if !mips {
                 cfg.header("linux/quota.h");

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -411,7 +411,6 @@ pub const TOSTOP: ::tcflag_t = 0x00000100;
 pub const FLUSHO: ::tcflag_t = 0x00001000;
 
 pub const MS_RMT_MASK: ::c_ulong = 0x800051;
-pub const MS_VERBOSE: ::c_ulong = 0x8000;
 
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;
 pub const AFFS_SUPER_MAGIC: ::c_long = 0x0000adff;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -410,8 +410,6 @@ pub const IEXTEN: ::tcflag_t = 0x00008000;
 pub const TOSTOP: ::tcflag_t = 0x00000100;
 pub const FLUSHO: ::tcflag_t = 0x00001000;
 
-pub const MS_RMT_MASK: ::c_ulong = 0x800051;
-
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;
 pub const AFFS_SUPER_MAGIC: ::c_long = 0x0000adff;
 pub const CODA_SUPER_MAGIC: ::c_long = 0x73757245;

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -356,7 +356,6 @@ pub const SIG_UNBLOCK: ::c_int = 0x2;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 131072;
 
-pub const MS_VERBOSE: ::c_ulong = 0x8000;
 pub const MS_RMT_MASK: ::c_ulong = 0x2800051;
 
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -356,8 +356,6 @@ pub const SIG_UNBLOCK: ::c_int = 0x2;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 131072;
 
-pub const MS_RMT_MASK: ::c_ulong = 0x800051;
-
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;
 pub const AFFS_SUPER_MAGIC: ::c_long = 0x0000adff;
 pub const CODA_SUPER_MAGIC: ::c_long = 0x73757245;

--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -356,7 +356,7 @@ pub const SIG_UNBLOCK: ::c_int = 0x2;
 
 pub const PTHREAD_STACK_MIN: ::size_t = 131072;
 
-pub const MS_RMT_MASK: ::c_ulong = 0x2800051;
+pub const MS_RMT_MASK: ::c_ulong = 0x800051;
 
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;
 pub const AFFS_SUPER_MAGIC: ::c_long = 0x0000adff;

--- a/src/unix/notbsd/linux/musl.rs
+++ b/src/unix/notbsd/linux/musl.rs
@@ -392,8 +392,6 @@ pub const MADV_DONTDUMP: ::c_int = 16;
 
 pub const EPOLLWAKEUP: ::c_int = 0x20000000;
 
-pub const MS_NOSEC: ::c_ulong = 0x10000000;
-pub const MS_BORN: ::c_ulong = 0x20000000;
 pub const MS_RMT_MASK: ::c_ulong = 0x800051;
 
 pub const MADV_HUGEPAGE: ::c_int = 14;

--- a/src/unix/notbsd/linux/musl.rs
+++ b/src/unix/notbsd/linux/musl.rs
@@ -392,8 +392,6 @@ pub const MADV_DONTDUMP: ::c_int = 16;
 
 pub const EPOLLWAKEUP: ::c_int = 0x20000000;
 
-pub const MS_RMT_MASK: ::c_ulong = 0x800051;
-
 pub const MADV_HUGEPAGE: ::c_int = 14;
 pub const MADV_NOHUGEPAGE: ::c_int = 15;
 pub const MAP_HUGETLB: ::c_int = 0x040000;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -356,9 +356,6 @@ pub const MADV_DONTDUMP: ::c_int = 16;
 
 pub const EPOLLWAKEUP: ::c_int = 0x20000000;
 
-pub const MS_NOSEC: ::c_ulong = 0x10000000;
-pub const MS_BORN: ::c_ulong = 0x20000000;
-
 pub const MADV_HUGEPAGE: ::c_int = 14;
 pub const MADV_NOHUGEPAGE: ::c_int = 15;
 pub const MAP_HUGETLB: ::c_int = 0x040000;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -283,8 +283,6 @@ pub const RUSAGE_CHILDREN: ::c_int = -1;
 pub const ST_RELATIME: ::c_ulong = 4096;
 pub const NI_MAXHOST: ::socklen_t = 1025;
 
-pub const MS_RMT_MASK: ::c_ulong = 0x800051;
-
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;
 pub const AFFS_SUPER_MAGIC: ::c_long = 0x0000adff;
 pub const CODA_SUPER_MAGIC: ::c_long = 0x73757245;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -283,7 +283,6 @@ pub const RUSAGE_CHILDREN: ::c_int = -1;
 pub const ST_RELATIME: ::c_ulong = 4096;
 pub const NI_MAXHOST: ::socklen_t = 1025;
 
-pub const MS_VERBOSE: ::c_ulong = 0x8000;
 pub const MS_RMT_MASK: ::c_ulong = 0x800051;
 
 pub const ADFS_SUPER_MAGIC: ::c_long = 0x0000adf5;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -254,6 +254,7 @@ pub const MS_ACTIVE: ::c_ulong = 0x40000000;
 pub const MS_NOUSER: ::c_ulong = 0x80000000;
 pub const MS_MGC_VAL: ::c_ulong = 0xc0ed0000;
 pub const MS_MGC_MSK: ::c_ulong = 0xffff0000;
+pub const MS_RMT_MASK: ::c_ulong = 0x800051;
 
 pub const EPERM: ::c_int = 1;
 pub const ENOENT: ::c_int = 2;


### PR DESCRIPTION
This is a fix for issue #113.

In `libc-test/build.rs`, the `main` function includes the directive `#include <linux/fs.h>` in the generated `all.c` file, but the correct header for system calls like `mount` is `<sys/mount.h>`; the `<linux/fs.h>` is just copied over from the kernel, and does not match the API offered by libc.

In particular:
- If you happen to include `<linux/fs.h>` before `<sys/mount.h>`, you'll get compilation errors, because the former defines the same constants using preprocessor macros that the latter defines as enum values. The generated `all.c` file just happens to include them in the other order.
- The `<linux/fs.h>` header includes a number of constants that are only meant to be used internal to the kernel, like `MS_NOSEC` and `MS_BORN`.
- The `<linux/fs.h>` header defines `MS_VERBOSE`, which is 1) a perverse name, because it silences some `printk` messages, rather than enabling them, and 2) is superseded by `MS_SILENT`, according to both the man page for `mount` and comments in the `<linux/fs.h>` header itself.

This pull request removes the libc crate's definitions for `MS_VERBOSE`, `MS_NOSEC`, and `MS_BORN`, and then removes the directive to include `<linux/fs.h>`.

This fixes issue #113 because the libc crate no longer sees the inappropriate-for-userspace definition of `MS_RMT_MASK`.