### PR TITLE
Add powerpc64 and powerpc64le support

### DIFF
--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -84,9 +84,11 @@ s! {
     }
 
     pub struct pthread_mutexattr_t {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(target_arch = "x86_64", target_arch = "powerpc64",
+                  target_arch = "powerpc64le"))]
         __align: [::c_int; 0],
-        #[cfg(not(target_arch = "x86_64"))]
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "powerpc64",
+                      target_arch = "powerpc64le")))]
         __align: [::c_long; 0],
         size: [u8; __SIZEOF_PTHREAD_MUTEXATTR_T],
     }

--- a/src/unix/notbsd/linux/other/b32/arm.rs
+++ b/src/unix/notbsd/linux/other/b32/arm.rs
@@ -4,3 +4,17 @@ pub type wchar_t = u32;
 pub const O_DIRECT: ::c_int = 0x10000;
 pub const O_DIRECTORY: ::c_int = 0x4000;
 pub const O_NOFOLLOW: ::c_int = 0x8000;
+
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+
+pub const EDEADLOCK: ::c_int = 35;
+
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_RCVTIMEO: ::c_int = 20;
+pub const SO_SNDTIMEO: ::c_int = 21;
+
+pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONBIO: ::c_ulong = 0x5421;

--- a/src/unix/notbsd/linux/other/b32/x86.rs
+++ b/src/unix/notbsd/linux/other/b32/x86.rs
@@ -4,3 +4,17 @@ pub type wchar_t = i32;
 pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
+
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+
+pub const EDEADLOCK: ::c_int = 35;
+
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_RCVTIMEO: ::c_int = 20;
+pub const SO_SNDTIMEO: ::c_int = 21;
+
+pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONBIO: ::c_ulong = 0x5421;

--- a/src/unix/notbsd/linux/other/b64/mod.rs
+++ b/src/unix/notbsd/linux/other/b64/mod.rs
@@ -22,6 +22,9 @@ cfg_if! {
     if #[cfg(target_arch = "aarch64")] {
         mod aarch64;
         pub use self::aarch64::*;
+    } else if #[cfg(any(target_arch = "powerpc64", target_arch = "powerpc64le"))] {
+        mod powerpc64;
+        pub use self::powerpc64::*;
     } else {
         mod x86_64;
         pub use self::x86_64::*;

--- a/src/unix/notbsd/linux/other/b64/powerpc64.rs
+++ b/src/unix/notbsd/linux/other/b64/powerpc64.rs
@@ -1,44 +1,43 @@
-//! AArch64-specific definitions for 64-bit linux-like values
+//! PowerPC64-specific definitions for 64-bit linux-like values
 
 pub type c_char = u8;
 pub type wchar_t = u32;
-pub type nlink_t = u32;
-pub type blksize_t = i32;
+pub type nlink_t = u64;
+pub type blksize_t = i64;
 
-pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 48;
-pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 8;
+pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;
+pub const __SIZEOF_PTHREAD_MUTEXATTR_T: usize = 4;
 
-pub const O_DIRECT: ::c_int = 0x10000;
 pub const O_DIRECTORY: ::c_int = 0x4000;
 pub const O_NOFOLLOW: ::c_int = 0x8000;
+pub const O_DIRECT: ::c_int = 0x20000;
 
-pub const MAP_LOCKED: ::c_int = 0x02000;
-pub const MAP_NORESERVE: ::c_int = 0x04000;
+pub const MAP_LOCKED: ::c_int = 0x00080;
+pub const MAP_NORESERVE: ::c_int = 0x00040;
 
-pub const EDEADLOCK: ::c_int = 35;
+pub const EDEADLOCK: ::c_int = 58;
 
-pub const SO_PEERCRED: ::c_int = 17;
-pub const SO_RCVLOWAT: ::c_int = 18;
-pub const SO_SNDLOWAT: ::c_int = 19;
-pub const SO_RCVTIMEO: ::c_int = 20;
-pub const SO_SNDTIMEO: ::c_int = 21;
+pub const SO_PEERCRED: ::c_int = 21;
+pub const SO_RCVLOWAT: ::c_int = 16;
+pub const SO_SNDLOWAT: ::c_int = 17;
+pub const SO_RCVTIMEO: ::c_int = 18;
+pub const SO_SNDTIMEO: ::c_int = 19;
 
-pub const FIOCLEX: ::c_ulong = 0x5451;
-pub const FIONBIO: ::c_ulong = 0x5421;
+pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONBIO: ::c_ulong = 0x8004667e;
 
 s! {
     pub struct stat {
         pub st_dev: ::dev_t,
         pub st_ino: ::ino_t,
-        pub st_mode: ::mode_t,
         pub st_nlink: ::nlink_t,
+        pub st_mode: ::mode_t,
         pub st_uid: ::uid_t,
         pub st_gid: ::gid_t,
+        __pad0: ::c_int,
         pub st_rdev: ::dev_t,
-        __pad1: ::dev_t,
         pub st_size: ::off_t,
         pub st_blksize: ::blksize_t,
-        __pad2: ::c_int,
         pub st_blocks: ::blkcnt_t,
         pub st_atime: ::time_t,
         pub st_atime_nsec: ::c_long,
@@ -46,21 +45,20 @@ s! {
         pub st_mtime_nsec: ::c_long,
         pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_long,
-        __unused: [::c_int; 2],
+        __unused: [::c_long; 3],
     }
 
     pub struct stat64 {
         pub st_dev: ::dev_t,
-        pub st_ino: ::ino_t,
-        pub st_mode: ::mode_t,
+        pub st_ino: ::ino64_t,
         pub st_nlink: ::nlink_t,
+        pub st_mode: ::mode_t,
         pub st_uid: ::uid_t,
         pub st_gid: ::gid_t,
+        __pad0: ::c_int,
         pub st_rdev: ::dev_t,
-        __pad1: ::dev_t,
         pub st_size: ::off64_t,
         pub st_blksize: ::blksize_t,
-        __pad2: ::c_int,
         pub st_blocks: ::blkcnt64_t,
         pub st_atime: ::time_t,
         pub st_atime_nsec: ::c_long,
@@ -68,10 +66,10 @@ s! {
         pub st_mtime_nsec: ::c_long,
         pub st_ctime: ::time_t,
         pub st_ctime_nsec: ::c_long,
-        __unused: [::c_int; 2],
+        __reserved: [::c_long; 3],
     }
 
     pub struct pthread_attr_t {
-        __size: [u64; 8]
+        __size: [u64; 7]
     }
 }

--- a/src/unix/notbsd/linux/other/b64/x86_64.rs
+++ b/src/unix/notbsd/linux/other/b64/x86_64.rs
@@ -12,6 +12,20 @@ pub const O_DIRECT: ::c_int = 0x4000;
 pub const O_DIRECTORY: ::c_int = 0x10000;
 pub const O_NOFOLLOW: ::c_int = 0x20000;
 
+pub const MAP_LOCKED: ::c_int = 0x02000;
+pub const MAP_NORESERVE: ::c_int = 0x04000;
+
+pub const EDEADLOCK: ::c_int = 35;
+
+pub const SO_PEERCRED: ::c_int = 17;
+pub const SO_RCVLOWAT: ::c_int = 18;
+pub const SO_SNDLOWAT: ::c_int = 19;
+pub const SO_RCVTIMEO: ::c_int = 20;
+pub const SO_SNDTIMEO: ::c_int = 21;
+
+pub const FIOCLEX: ::c_ulong = 0x5451;
+pub const FIONBIO: ::c_ulong = 0x5421;
+
 pub const PTRACE_GETFPREGS: ::c_uint = 14;
 pub const PTRACE_SETFPREGS: ::c_uint = 15;
 pub const PTRACE_GETFPXREGS: ::c_uint = 18;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -110,8 +110,6 @@ pub const MAP_ANONYMOUS: ::c_int = 0x0020;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;
 pub const MAP_DENYWRITE: ::c_int = 0x0800;
 pub const MAP_EXECUTABLE: ::c_int = 0x01000;
-pub const MAP_LOCKED: ::c_int = 0x02000;
-pub const MAP_NORESERVE: ::c_int = 0x04000;
 pub const MAP_POPULATE: ::c_int = 0x08000;
 pub const MAP_NONBLOCK: ::c_int = 0x010000;
 pub const MAP_STACK: ::c_int = 0x020000;
@@ -138,7 +136,6 @@ pub const EXFULL: ::c_int = 54;
 pub const ENOANO: ::c_int = 55;
 pub const EBADRQC: ::c_int = 56;
 pub const EBADSLT: ::c_int = 57;
-pub const EDEADLOCK: ::c_int = EDEADLK;
 pub const EMULTIHOP: ::c_int = 72;
 pub const EOVERFLOW: ::c_int = 75;
 pub const ENOTUNIQ: ::c_int = 76;
@@ -217,11 +214,6 @@ pub const SO_KEEPALIVE: ::c_int = 9;
 pub const SO_OOBINLINE: ::c_int = 10;
 pub const SO_LINGER: ::c_int = 13;
 pub const SO_REUSEPORT: ::c_int = 15;
-pub const SO_PEERCRED: ::c_int = 17;
-pub const SO_RCVLOWAT: ::c_int = 18;
-pub const SO_SNDLOWAT: ::c_int = 19;
-pub const SO_RCVTIMEO: ::c_int = 20;
-pub const SO_SNDTIMEO: ::c_int = 21;
 pub const SO_ACCEPTCONN: ::c_int = 30;
 
 pub const TCP_COOKIE_TRANSACTIONS: ::c_int = 15;
@@ -266,9 +258,6 @@ pub const SIG_UNBLOCK: ::c_int = 0x01;
 
 pub const FALLOC_FL_KEEP_SIZE: ::c_int = 0x01;
 pub const FALLOC_FL_PUNCH_HOLE: ::c_int = 0x02;
-
-pub const FIOCLEX: ::c_ulong = 0x5451;
-pub const FIONBIO: ::c_ulong = 0x5421;
 
 pub const BUFSIZ: ::c_uint = 8192;
 pub const TMP_MAX: ::c_uint = 238328;
@@ -443,7 +432,10 @@ cfg_if! {
     if #[cfg(any(target_arch = "x86", target_arch = "arm"))] {
         mod b32;
         pub use self::b32::*;
-    } else if #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
+    } else if #[cfg(any(target_arch = "x86_64",
+                        target_arch = "aarch64",
+                        target_arch = "powerpc64",
+                        target_arch = "powerpc64le"))] {
         mod b64;
         pub use self::b64::*;
     } else {


### PR DESCRIPTION
PowerPC64 Linux does not implement fstat64, stat64 and lstat64, so
disable them. A number of constants for system calls are different
to x86, so fix that too.