### PR TITLE
Preliminary PowerPC Support

### DIFF
--- a/src/unix/notbsd/linux/other/b32/mod.rs
+++ b/src/unix/notbsd/linux/other/b32/mod.rs
@@ -86,6 +86,9 @@ cfg_if! {
     } else if #[cfg(target_arch = "arm")] {
         mod arm;
         pub use self::arm::*;
+    } else if #[cfg(target_arch = "powerpc")] {
+        mod powerpc;
+        pub use self::powerpc::*;
     } else {
         // ...
     }

--- a/src/unix/notbsd/linux/other/b32/powerpc.rs
+++ b/src/unix/notbsd/linux/other/b32/powerpc.rs
@@ -1,0 +1,20 @@
+pub type c_char = u8;
+pub type wchar_t = i32;
+
+pub const O_DIRECT: ::c_int = 0x20000;
+pub const O_DIRECTORY: ::c_int = 0x4000;
+pub const O_NOFOLLOW: ::c_int = 0x8000;
+
+pub const MAP_LOCKED: ::c_int = 0x00080;
+pub const MAP_NORESERVE: ::c_int = 0x00040;
+
+pub const EDEADLOCK: ::c_int = 58;
+
+pub const SO_PEERCRED: ::c_int = 21;
+pub const SO_RCVLOWAT: ::c_int = 16;
+pub const SO_SNDLOWAT: ::c_int = 17;
+pub const SO_RCVTIMEO: ::c_int = 18;
+pub const SO_SNDTIMEO: ::c_int = 19;
+
+pub const FIOCLEX: ::c_ulong = 0x20006601;
+pub const FIONBIO: ::c_ulong = 0x8004667e;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -429,7 +429,9 @@ extern {
 }
 
 cfg_if! {
-    if #[cfg(any(target_arch = "x86", target_arch = "arm"))] {
+    if #[cfg(any(target_arch = "x86",
+                 target_arch = "arm",
+                 target_arch = "powerpc"))] {
         mod b32;
         pub use self::b32::*;
     } else if #[cfg(any(target_arch = "x86_64",


### PR DESCRIPTION
Original pull request: https://github.com/rust-lang-nursery/libc/pull/141

These values were checked from a MintPPC machine using the following C program:

```
#include <sys/ptrace.h>
#include <sys/ioctl.h>
#include <sys/errno.h>
#include <sys/mman.h>
#include <fcntl.h>
#include <sys/socket.h>
#include <stdio.h>
#include <pthread.h>

int main() {
  printf("O_DIRECT: 0x%x\n", O_DIRECT);
  printf("O_DIRECTORY: 0x%x\n", O_DIRECTORY);
  printf("O_NOFOLLOW: 0x%x\n", O_NOFOLLOW);

  printf("MAP_LOCKED: 0x%x\n", MAP_LOCKED);
  printf("MAP_NORESERVE: 0x%x\n", MAP_NORESERVE);

  printf("EDEADLK: %d\n", EDEADLK);
  printf("EDEADLOCK: %d\n", EDEADLOCK);

  printf("sizeof(pthread_mutex_t): %d\n", sizeof(pthread_mutex_t));
  printf("sizeof(pthread_rwlock_t): %d\n", sizeof(pthread_rwlock_t));
  printf("sizeof(pthread_mutexattr_t): %d\n", sizeof(pthread_mutexattr_t));

  printf("SO_PEERCRED: %d\n", SO_PEERCRED);
  printf("SO_RCVLOWAT: %d\n", SO_RCVLOWAT);
  printf("SO_SNDLOWAT: %d\n", SO_SNDLOWAT);
  printf("SO_RCVTIMEO: %d\n", SO_RCVTIMEO);
  printf("SO_SNDTIMEO: %d\n", SO_SNDTIMEO);

  printf("FIOCLEX: 0x%x\n", FIOCLEX);
  printf("FIONBIO: 0x%x\n", FIONBIO);
}

$ gcc -D_GNU_SOURCE -o test test.c
$ ./test
$ ./test
O_DIRECT: 0x20000
O_DIRECTORY: 0x4000
O_NOFOLLOW: 0x8000
MAP_LOCKED: 0x80
MAP_NORESERVE: 0x40
EDEADLK: 35
EDEADLOCK: 58
sizeof(pthread_mutex_t): 24
sizeof(pthread_rwlock_t): 32
sizeof(pthread_mutexattr_t): 4
SO_PEERCRED: 21
SO_RCVLOWAT: 16
SO_SNDLOWAT: 17
SO_RCVTIMEO: 18
SO_SNDTIMEO: 19
FIOCLEX: 0x20006601
FIONBIO: 0x8004667e
```