### PR TITLE
Add a default-on std feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 dist: trusty
 rust:
   - 1.0.0
+  - stable
   - beta
   - nightly
 services:
@@ -10,8 +11,11 @@ services:
 script:
   - if [[ $TRAVIS_RUST_VERSION = nightly* ]]; then
       sh ci/run-travis.sh;
+    elif [[ $TRAVIS_RUST_VERSION = "1.0.0" ]]; then
+      cargo build;
     else
       cargo build;
+      cargo build --no-default-features;
     fi
 os:
   - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ other common platform libraries.
 """
 
 [features]
-default = []
+default = ["use_std"]
+use_std = []

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Next, add this to your crate root:
 extern crate libc;
 ```
 
+Currently libc by default links to the standard library, but if you would
+instead like to use libc in a `#![no_std]` situation or crate you can request
+this via:
+
+```toml
+[dependencies]
+libc = { version = "0.2", default-features = false }
+```
+
 ## What is libc?
 
 The primary purpose of this crate is to provide all of the definitions necessary

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,9 @@
                                reason = "use `libc` from crates.io",
                                issue = "27783"))]
 
-#[cfg(all(not(stdbuild), not(dox)))]
+#![cfg_attr(not(feature = "use_std"), no_std)]
+
+#[cfg(all(not(stdbuild), not(dox), feature = "use_std"))]
 extern crate std as core;
 
 #[macro_use] mod macros;


### PR DESCRIPTION


This adds a `std` Cargo feature which disables `#![no_std]` builds of libc, but
is enabled by default. The library will currently continue to link to the
standard library to maintain backwards compatibility with the 0.2 series and
older Rust compilers for now, but this default can possible be changed in the
future.
