### PR TITLE
Add SOCK_NONBLOCK & SOCK_CLOEXEC

### DIFF
--- a/src/unix/notbsd/linux/mips.rs
+++ b/src/unix/notbsd/linux/mips.rs
@@ -205,6 +205,8 @@ pub const O_FSYNC: ::c_int = 0x4010;
 pub const O_ASYNC: ::c_int = 0x1000;
 pub const O_NDELAY: ::c_int = 0x80;
 
+pub const SOCK_NONBLOCK: ::c_int = 128;
+
 pub const EDEADLK: ::c_int = 45;
 pub const ENAMETOOLONG: ::c_int = 78;
 pub const ENOLCK: ::c_int = 46;

--- a/src/unix/notbsd/linux/musl.rs
+++ b/src/unix/notbsd/linux/musl.rs
@@ -190,6 +190,8 @@ pub const O_SYNC: ::c_int = 1052672;
 pub const O_RSYNC: ::c_int = 1052672;
 pub const O_DSYNC: ::c_int = 4096;
 
+pub const SOCK_NONBLOCK: ::c_int = 2048;
+
 pub const MAP_ANON: ::c_int = 0x0020;
 pub const MAP_ANONYMOUS: ::c_int = 0x0020;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;

--- a/src/unix/notbsd/linux/other/mod.rs
+++ b/src/unix/notbsd/linux/other/mod.rs
@@ -105,6 +105,8 @@ pub const O_RSYNC: ::c_int = 1052672;
 pub const O_DSYNC: ::c_int = 4096;
 pub const O_FSYNC: ::c_int = 0x101000;
 
+pub const SOCK_NONBLOCK: ::c_int = O_NONBLOCK;
+
 pub const MAP_ANON: ::c_int = 0x0020;
 pub const MAP_ANONYMOUS: ::c_int = 0x0020;
 pub const MAP_GROWSDOWN: ::c_int = 0x0100;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -174,6 +174,9 @@ pub const O_WRONLY: ::c_int = 1;
 pub const O_RDWR: ::c_int = 2;
 pub const O_TRUNC: ::c_int = 512;
 pub const O_CLOEXEC: ::c_int = 0x80000;
+
+pub const SOCK_CLOEXEC: ::c_int = O_CLOEXEC; 
+
 pub const S_IFIFO: ::mode_t = 4096;
 pub const S_IFCHR: ::mode_t = 8192;
 pub const S_IFBLK: ::mode_t = 24576;


### PR DESCRIPTION
I've added the Linux-specific flags for #115

It helps to support the flag that is used to create a non blocking socket in one kernel call instead of two.