### PR TITLE
Renames "sunos" to "solaris" (as a part of PR to add Illumos support to Rust)

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -693,9 +693,9 @@ cfg_if! {
                         target_os = "bitrig"))] {
         mod bsd;
         pub use self::bsd::*;
-    } else if #[cfg(target_os = "sunos")] {
-        mod sunos;
-        pub use self::sunos::*;
+    } else if #[cfg(target_os = "solaris")] {
+        mod solaris;
+        pub use self::solaris::*;
     } else {
         // ...
     }

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -322,6 +322,7 @@ pub const O_EXCL: ::c_int = 1024;
 pub const O_NOCTTY: ::c_int = 2048;
 pub const O_TRUNC: ::c_int = 512;
 pub const O_CLOEXEC: ::c_int = 0x800000;
+pub const O_ACCMODE: ::c_int = 0x600003;
 pub const S_IFIFO: mode_t = 4096;
 pub const S_IFCHR: mode_t = 8192;
 pub const S_IFBLK: mode_t = 24576;


### PR DESCRIPTION
This PR is required for https://github.com/rust-lang/rust/pull/31078, as it was decided to change "sunos" to "solaris" as a platform identifier.

Also, it adds a missing constant introduced in latest commits for other platforms.