### PR TITLE
musl: define nlink_t as u32/u64

### DIFF
--- a/src/unix/notbsd/linux/musl/b32/mod.rs
+++ b/src/unix/notbsd/linux/musl/b32/mod.rs
@@ -1,5 +1,6 @@
 pub type c_long = i32;
 pub type c_ulong = u32;
+pub type nlink_t = u32;
 
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 32;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 24;

--- a/src/unix/notbsd/linux/musl/b64/mod.rs
+++ b/src/unix/notbsd/linux/musl/b64/mod.rs
@@ -2,6 +2,7 @@ pub type c_char = i8;
 pub type wchar_t = i32;
 pub type c_long = i64;
 pub type c_ulong = u64;
+pub type nlink_t = u64;
 
 pub const __SIZEOF_PTHREAD_RWLOCK_T: usize = 56;
 pub const __SIZEOF_PTHREAD_MUTEX_T: usize = 40;

--- a/src/unix/notbsd/linux/musl/mod.rs
+++ b/src/unix/notbsd/linux/musl/mod.rs
@@ -5,7 +5,6 @@ pub type ino_t = u64;
 pub type off_t = i64;
 pub type blkcnt_t = i64;
 
-pub type nlink_t = usize;
 pub type blksize_t = c_long;
 pub type fsblkcnt_t = ::c_ulonglong;
 pub type fsfilcnt_t = ::c_ulonglong;


### PR DESCRIPTION
Fixes the failed test in rust-lang/rust#31298

r? @alexcrichton 