### PR TITLE
Define _SC_PAGE_SIZE constants

### DIFF
--- a/src/unix/bsd/freebsdlike/mod.rs
+++ b/src/unix/bsd/freebsdlike/mod.rs
@@ -548,6 +548,7 @@ pub const _SC_AIO_PRIO_DELTA_MAX: ::c_int = 44;
 pub const _SC_DELAYTIMER_MAX: ::c_int = 45;
 pub const _SC_MQ_OPEN_MAX: ::c_int = 46;
 pub const _SC_PAGESIZE: ::c_int = 47;
+pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_RTSIG_MAX: ::c_int = 48;
 pub const _SC_SEM_NSEMS_MAX: ::c_int = 49;
 pub const _SC_SEM_VALUE_MAX: ::c_int = 50;

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -362,6 +362,7 @@ pub const _SC_2_UPE : ::c_int = 25;
 pub const _SC_STREAM_MAX : ::c_int = 26;
 pub const _SC_TZNAME_MAX : ::c_int = 27;
 pub const _SC_PAGESIZE : ::c_int = 28;
+pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_FSYNC : ::c_int = 29;
 
 pub const KERN_PROC_ARGV: ::c_int = 1;

--- a/src/unix/notbsd/android/mod.rs
+++ b/src/unix/notbsd/android/mod.rs
@@ -196,6 +196,7 @@ pub const _SC_XOPEN_LEGACY: ::c_int = 36;
 pub const _SC_ATEXIT_MAX: ::c_int = 37;
 pub const _SC_IOV_MAX: ::c_int = 38;
 pub const _SC_PAGESIZE: ::c_int = 39;
+pub const _SC_PAGE_SIZE: ::c_int = 40;
 pub const _SC_XOPEN_UNIX: ::c_int = 41;
 pub const _SC_MQ_PRIO_MAX: ::c_int = 51;
 pub const _SC_GETGR_R_SIZE_MAX: ::c_int = 71;

--- a/src/unix/notbsd/linux/mod.rs
+++ b/src/unix/notbsd/linux/mod.rs
@@ -220,6 +220,7 @@ pub const _SC_MQ_OPEN_MAX: ::c_int = 27;
 pub const _SC_MQ_PRIO_MAX: ::c_int = 28;
 pub const _SC_VERSION: ::c_int = 29;
 pub const _SC_PAGESIZE: ::c_int = 30;
+pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_RTSIG_MAX: ::c_int = 31;
 pub const _SC_SEM_NSEMS_MAX: ::c_int = 32;
 pub const _SC_SEM_VALUE_MAX: ::c_int = 33;

--- a/src/unix/notbsd/mod.rs
+++ b/src/unix/notbsd/mod.rs
@@ -175,7 +175,7 @@ pub const O_RDWR: ::c_int = 2;
 pub const O_TRUNC: ::c_int = 512;
 pub const O_CLOEXEC: ::c_int = 0x80000;
 
-pub const SOCK_CLOEXEC: ::c_int = O_CLOEXEC; 
+pub const SOCK_CLOEXEC: ::c_int = O_CLOEXEC;
 
 pub const S_IFIFO: ::mode_t = 4096;
 pub const S_IFCHR: ::mode_t = 8192;

--- a/src/unix/solaris/mod.rs
+++ b/src/unix/solaris/mod.rs
@@ -626,6 +626,7 @@ pub const _SC_JOB_CONTROL: ::c_int = 6;
 pub const _SC_SAVED_IDS: ::c_int = 7;
 pub const _SC_VERSION: ::c_int = 8;
 pub const _SC_PAGESIZE: ::c_int = 11;
+pub const _SC_PAGE_SIZE: ::c_int = _SC_PAGESIZE;
 pub const _SC_NPROCESSORS_ONLN: ::c_int = 15;
 pub const _SC_STREAM_MAX: ::c_int = 16;
 pub const _SC_TZNAME_MAX: ::c_int = 17;


### PR DESCRIPTION
According to POSIX, sysconf can take _SC_PAGESIZE or _SC_PAGE_SIZE,
which may be the same value.  This constant was defined in "apple" as
equal to _SC_PAGESIZE, but not any of the other platforms.

Add definitions for _SC_PAGE_SIZE for all platforms which had
_SC_PAGESIZE defined. On all platforms but Android (Bionic), they are
the same value; on Android _SC_PAGE_SIZE has a different value.