### PR TITLE
Add abort

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,7 @@ extern {
     pub fn malloc(size: size_t) -> *mut c_void;
     pub fn realloc(p: *mut c_void, size: size_t) -> *mut c_void;
     pub fn free(p: *mut c_void);
+    pub fn abort() -> !;
     pub fn exit(status: c_int) -> !;
     pub fn _exit(status: c_int) -> !;
     pub fn atexit(cb: extern fn()) -> c_int;


### PR DESCRIPTION
This is defined by the C standard to indicate abnormal program
terminaiton; it is defined to call raise(SIGABRT), and to not return.
This can be useful when panics are not an option, such as signal
handlers handling stack overflow.