### PR TITLE
fixes the bitrig d_namlen compile error

### DIFF
--- a/src/unix/bsd/openbsdlike/bitrig.rs
+++ b/src/unix/bsd/openbsdlike/bitrig.rs
@@ -17,7 +17,7 @@ s! {
         pub d_off: ::off_t,
         pub d_reclen: u16,
         pub d_type: u8,
-        pub d_namelen: u8,
+        pub d_namlen: u8,
         __d_padding: [u8; 4],
         pub d_name: [::c_char; 256],
     }


### PR DESCRIPTION
@alexcrichton this fixes the current build breakage for the bitrig build: 
```
./src/libstd/sys/unix/fs.rs:221:37: 221:56 error: attempted access of field `d_namlen` on type `libc::unix::bsd::openbsdlike::bitrig::dirent`, but no field with that name was found
../src/libstd/sys/unix/fs.rs:221                                     self.entry.d_namlen as usize)
                                                                     ^~~~~~~~~~~~~~~~~~~
../src/libstd/sys/unix/fs.rs:221:48: 221:56 help: did you mean `d_namelen`?
../src/libstd/sys/unix/fs.rs:221                                     self.entry.d_namlen as usize)
                                                                                ^~~~~~~~
```