### PR TITLE
SIGSTKSZ is the same on OpenBSD, Bitrig, and NetBSD

### DIFF
--- a/src/unix/bsd/openbsdlike/bitrig.rs
+++ b/src/unix/bsd/openbsdlike/bitrig.rs
@@ -202,8 +202,6 @@ pub const _SC_RTSIG_MAX : ::c_int = 66;
 pub const _SC_SIGQUEUE_MAX : ::c_int = 70;
 pub const _SC_TIMER_MAX : ::c_int = 93;
 
-pub const SIGSTKSZ: ::size_t = 131072;
-
 pub const FD_SETSIZE: usize = 1024;
 
 pub const ST_NOSUID: ::c_ulong = 2;

--- a/src/unix/bsd/openbsdlike/mod.rs
+++ b/src/unix/bsd/openbsdlike/mod.rs
@@ -123,6 +123,7 @@ pub const SIGSEGV : ::c_int = 11;
 pub const SIGPIPE : ::c_int = 13;
 pub const SIGALRM : ::c_int = 14;
 pub const SIGTERM : ::c_int = 15;
+pub const SIGSTKSZ : ::size_t = 40960;
 
 pub const PROT_NONE : ::c_int = 0;
 pub const PROT_READ : ::c_int = 1;

--- a/src/unix/bsd/openbsdlike/netbsd.rs
+++ b/src/unix/bsd/openbsdlike/netbsd.rs
@@ -269,8 +269,6 @@ pub const _SC_SHARED_MEMORY_OBJECTS : ::c_int = 87;
 pub const _SC_SYNCHRONIZED_IO : ::c_int = 31;
 pub const _SC_TIMERS : ::c_int = 44;
 
-pub const SIGSTKSZ: ::size_t = 0xa000;
-
 pub const FD_SETSIZE: usize = 0x100;
 
 pub const ST_NOSUID: ::c_ulong = 8;

--- a/src/unix/bsd/openbsdlike/openbsd.rs
+++ b/src/unix/bsd/openbsdlike/openbsd.rs
@@ -205,8 +205,6 @@ pub const _SC_RTSIG_MAX : ::c_int = 66;
 pub const _SC_SIGQUEUE_MAX : ::c_int = 70;
 pub const _SC_TIMER_MAX : ::c_int = 93;
 
-pub const SIGSTKSZ: ::size_t = 40960;
-
 pub const FD_SETSIZE: usize = 1024;
 
 pub const ST_NOSUID: ::c_ulong = 2;


### PR DESCRIPTION
I investigated SIGSTKSZ on all three OSes and they are the same: 40960.